### PR TITLE
feat(aos-packages): allow create update delete sql statements #1)

### DIFF
--- a/packages/db-admin/src/DbAdmin.lua
+++ b/packages/db-admin/src/DbAdmin.lua
@@ -34,4 +34,20 @@ function dbAdmin:exec(sql)
     return results
 end
 
+-- Function to apply SQL INSERT, UPDATE, and DELETE statements with parameter binding
+function dbAdmin:apply(sql, values)
+    local DONE = require('lsqlite3').DONE
+    assert(type(sql) == 'string', 'SQL MUST be a String')
+    assert(type(values) == 'table', 'values MUST be an array of values')
+    
+    local stmt = self.db:prepare(sql)
+    stmt:bind_values(table.unpack(values))
+    
+    if stmt:step() ~= DONE then
+        error(sql .. ' statement failed because ' .. self.db:errmsg())
+    end
+    
+    stmt:finalize()
+end
+
 return dbAdmin

--- a/packages/db-admin/src/run_tests.lua
+++ b/packages/db-admin/src/run_tests.lua
@@ -24,6 +24,26 @@ t:add("Count Records", function ()
   assert(results == 3, "3 records found in test")
 end)
 
+-- Test: Apply Insert
+t:add("Apply Insert", function()
+  dbAdmin:apply('INSERT INTO test (content) VALUES (?);', {"Hello World"})
+  local results = dbAdmin:exec('SELECT * FROM test WHERE content = "Hello World";')
+  assert(#results == 1, "Expected 1 record with content 'Hello World'")
+end)
+
+-- Test: Apply Update
+t:add("Apply Update", function()
+  dbAdmin:apply('UPDATE test SET content = ? WHERE content = ?;', {"Updated Content", "Hello World"})
+  local results = dbAdmin:exec('SELECT * FROM test WHERE content = "Updated Content";')
+  assert(#results == 1, "Expected 1 record with updated content 'Updated Content'")
+end)
+
+-- Test: Apply Delete
+t:add("Apply Delete", function()
+  dbAdmin:apply('DELETE FROM test WHERE content = ?;', {"Updated Content"})
+  local results = dbAdmin:exec('SELECT * FROM test WHERE content = "Updated Content";')
+  assert(#results == 0, "Expected no records with content 'Updated Content'")
+end)
 
 return t:run()
 


### PR DESCRIPTION
This PR allows for the Create, Update, and Delete sql functions with parameters using `apply`.

example
```bash
 dbAdmin:apply('insert into test (id, content) values (?,?);', { NULL, "Hello World" })
```

then to see the updated table:
```bash
dbAdmin:exec("select * from test")
```

you will see a new line with content equal to "Hello World"