### PR TITLE
feat(aos-packages): allow sql select statements with parameters #2

### DIFF
--- a/packages/db-admin/src/DbAdmin.lua
+++ b/packages/db-admin/src/DbAdmin.lua
@@ -50,4 +50,30 @@ function dbAdmin:apply(sql, values)
     stmt:finalize()
 end
 
+-- Function to apply SQL SELECT statements with parameter binding
+function dbAdmin:select(sql, values)
+   local sqlite3 = require('lsqlite3')
+   local DONE = sqlite3.DONE
+   assert(type(sql) == 'string', 'SQL MUST be a String')
+   assert(type(values) == 'table', 'values MUST be an array of values')
+
+   local stmt = self.db:prepare(sql)
+   stmt:bind_values(table.unpack(values))
+
+   local results = {}
+   while true do
+       local row = stmt:step()
+       if row == sqlite3.ROW then
+           table.insert(results, stmt:get_named_values()) 
+       elseif row == DONE then
+           break
+       else
+           error(sql .. ' statement failed because ' .. self.db:errmsg())
+       end
+   end
+
+   stmt:finalize()
+   return results
+end
+
 return dbAdmin

--- a/packages/db-admin/src/run_tests.lua
+++ b/packages/db-admin/src/run_tests.lua
@@ -44,6 +44,13 @@ t:add("Apply Delete", function()
   local results = dbAdmin:exec('SELECT * FROM test WHERE content = "Updated Content";')
   assert(#results == 0, "Expected no records with content 'Updated Content'")
 end)
+t:add("Apply Select", function ()
+  local results = dbAdmin:select('SELECT * FROM test WHERE content = ? OR content = ?;', {'Hello ao!!!', "Hello Sqlite3"})
+  assert(#results == 2, "Expected 2 records with content 'Hello ao!!!' OR 'Hello Sqlite3'")
+  assert(results[1].content == 'Hello Sqlite3', "Record content should be 'Hello Sqlite3'")
+  assert(results[2].content == 'Hello ao!!!', "Record content should be 'Hello ao!!!'")
+end)
+
 
 return t:run()
 


### PR DESCRIPTION
This PR allows for select statements with parameters using `select`

example:

```bash
dbAdmin:select('SELECT * FROM test WHERE content = ? OR content = ?;', {'Hello ao!!!', "Hello Lua"})
```

returns:
```bash
{
  {
     content = "Hello Lua",
     id = 1
  },
  {
     content = "Hello ao!!!",
     id = 3
  }
 }
```