### PR TITLE
fix(allocator): fix rounding error, make sure remainder addition is cast to string

### DIFF
--- a/packages/allocator/README.md
+++ b/packages/allocator/README.md
@@ -1,9 +1,8 @@
 # Allocator
 
-Allocate a reward to a set of balances. When wanting to distribute rewards to a set of addresses based on the weight of their balance, this package does exactly that. 
+Allocate a reward to a set of balances. When wanting to distribute rewards to a set of addresses based on the weight of their balance, this package does exactly that.
 
 ## Usage
-
 
 ```lua
 -- Example usage

--- a/packages/allocator/src/main.lua
+++ b/packages/allocator/src/main.lua
@@ -59,8 +59,8 @@ function allocator.allocate(balances, reward)
             end
             
             local pct = (balance / total) * bint(100)
-            local coins = math.floor(bint(reward) * (pct / bint(100)) + (bint(1) / bint(2))) -- Round to nearest integer
-            
+            local coins = math.floor(bint(reward) * (pct / bint(100)))
+
             table.insert(a, {[asset] = tostring(coins)})
             return a
         end, {}, (function()
@@ -77,7 +77,7 @@ function allocator.allocate(balances, reward)
     local k = keys(allocation)
     local i = 1
     while remainder > 0 do
-        allocation[k[i]] = allocation[k[i]] + 1
+        allocation[k[i]] = tostring(bint(allocation[k[i]]) + bint(1))
         remainder = remainder - 1
         i = (i % #k) + 1
     end

--- a/packages/allocator/src/main.test.lua
+++ b/packages/allocator/src/main.test.lua
@@ -1,0 +1,80 @@
+local allocator = require("main")
+local testUnit = require("@rakis/test-unit")
+local t = testUnit.new("Allocator Tests")
+-- helper
+function TableSum(T)
+  local sum = 0
+  for _, v in pairs(T) do sum = sum + v end
+  return sum
+end
+
+t:add(
+  "Allocate, no remainder", 
+  function()
+    local testBalances = { 
+      Address1 = 1,
+      Address2 = 1
+    }
+    local reward = 100
+    local result = allocator.allocate(testBalances, reward)
+
+    assert(result['Address1'] == "50" and result['Address2'] == "50", 'Reward should be split evenly')
+    assert(TableSum(result) == reward, 'Reward should be fully distributed')
+  end
+)
+
+t:add(
+  "Allocate, remainder", 
+  function()
+    local testBalances = { 
+      Address1 = 1,
+      Address2 = 1
+    }
+    local reward = 101
+    local result = allocator.allocate(testBalances, reward)
+
+    assert(result['Address1'] == "51", 'Reward should be split evenly, address 1 gets remainder')
+    assert(result['Address2'] == "50", 'Reward should be split evenly, address 2 gets no remainder')
+    assert(TableSum(result) == reward, 'Reward should be fully distributed')
+  end
+)
+
+t:add(
+  "Allocate, multiple remainders", 
+  function()
+    local testBalances = { 
+      Address1 = 1,
+      Address2 = 1,
+      Address3 = 1
+    }
+    local reward = 101
+    local result = allocator.allocate(testBalances, reward)
+
+    assert(result['Address1'] == "34", 'Reward should be split evenly, address 1 gets remainder')
+    assert(result['Address2'] == "33", 'Reward should be split evenly, address 2 gets no remainder')
+    assert(result['Address3'] == "34", 'Reward should be split evenly, address 3 gets remainder')
+
+    assert(TableSum(result) == reward, 'Reward should be fully distributed')
+  end
+)
+t:add(
+  "Allocate, multiple remainders, rounding error", 
+  function()
+    local testBalances = { 
+      Address1 = 11, -- (11/77) * 102 = 14.57, floors to 14 | + 1 remainder | 15
+      Address2 = 21, -- (21/77) * 102 = 27.81, floors to 27 | + 0 remainder | 27
+      Address3 = 45  -- (45/77) * 102 = 59.61, floors to 59 | + 1 remainder | 60
+    }
+    local reward = 102
+    local result = allocator.allocate(testBalances, reward)
+
+    assert(result['Address1'] == "15", 'Reward should be split percentage wise, address 1 gets remainder')
+    assert(result['Address2'] == "27", 'Reward should be split percentage wise, address 2 gets no remainder')
+    assert(result['Address3'] == "60", 'Reward should be split percentage wise, address 3 gets remainder')
+
+    assert(TableSum(result) == reward, 'Reward should be fully distributed')
+  end
+)
+
+return t:run()
+


### PR DESCRIPTION
Added allocator tests.

Sometimes, there can be a rounding error which causes the allocator to 'over-allocate' the reward. Fixes this.
Additionally, casts to string after remainder is added to allocation.